### PR TITLE
Função para alterar o arquivo de endpoints

### DIFF
--- a/src/Gerencianet/Config.php
+++ b/src/Gerencianet/Config.php
@@ -4,10 +4,33 @@ namespace Gerencianet;
 
 class Config
 {
+    /**
+     * @var string Arquivo de configuração dos endpoints
+     */
+    private static $endpointsConfigfile = __DIR__ . '/config.json';
+
+    /**
+     * Altera arquivo de configuração
+     * @param string $file Caminho do arquivo
+     */
+    public static function setEndpointsConfigFile($file)
+    {
+        self::$endpointsConfigfile = $file;
+    }
+
+    /**
+     * Carrega as configurações do arquivo de endpoints
+     * @param string $property Chave do parâmetro
+     * @return mixed
+     */
     public static function get($property)
     {
-        $file = file_get_contents(__DIR__.'/config.json');
+        $file = file_get_contents(self::$endpointsConfigfile);
         $config = json_decode($file, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Exception("Erro ao carregar endpoints do arquivo");
+        }
 
         if (isset($config[$property])) {
             return $config[$property];

--- a/src/Gerencianet/Gerencianet.php
+++ b/src/Gerencianet/Gerencianet.php
@@ -4,4 +4,12 @@ namespace Gerencianet;
 
 class Gerencianet extends Endpoints
 {
+    public function __construct($options, $requester = null, $endpointsConfigFile = null)
+    {
+        if ($endpointsConfigFile) {
+            Config::setEndpointsConfigFile($endpointsConfigFile);
+        }
+
+        parent::__construct($options, $requester);
+    }
 }


### PR DESCRIPTION
Tendo em vista que o arquivo de endpoints pode conter rotas diferentes de um parceiro para outro ou de um parceiro para um usuário ele acabar sendo reescrito em uma atualização do pacote, perdendo assim as alterações individuais.
