### PR TITLE
Corrige Docblocks com métodos da API

### DIFF
--- a/src/Gerencianet/Gerencianet.php
+++ b/src/Gerencianet/Gerencianet.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Gerencianet;
+
 /**
  * Class Gerencianet
  * @package Gerencianet
@@ -116,9 +118,6 @@
  * @method array accountDetailWebhook(array $params)
  * @method array accountListWebhook(array $params)
  */
-
-namespace Gerencianet;
-
 class Gerencianet extends Endpoints
 {
     public function __construct($options, $requester = null, $endpointsConfigFile = null)


### PR DESCRIPTION
Os docblocks com os métodos da API é um recurso extremamente útil para os desenvolvedores, e que bom que a biblioteca faz uso deste recurso. No entanto, ele não está servindo de nada atualmente, pois está no local incorreto.

Este PR apenas move os docblocks para imediatamente acima da declaração da classe. Com esta pequena modificação podemos desfrutar dos recursos de autocomplete dos métodos do SDK.